### PR TITLE
modbus: check integer overflow with address and quantity

### DIFF
--- a/sawp-modbus/src/lib.rs
+++ b/sawp-modbus/src/lib.rs
@@ -3218,6 +3218,26 @@ mod tests {
                 error_flags: ErrorFlags::none(),
             },
             None
+        ),
+        // test with overflow of address + quantity
+        case::read_file_record(
+            Message{
+                transaction_id: 1,
+                protocol_id: 0,
+                length: 10,
+                unit_id: 1,
+                function: Function { raw: 1, code: FunctionCode::RdCoils },
+                access_type: AccessType::COILS | AccessType::READ,
+                category: CodeCategory::PUBLIC_ASSIGNED.into(),
+                data: Data::Read (
+                    Read::Request {
+                        address: 0xA000,
+                        quantity: 0xC000,
+                    }
+                ),
+                error_flags: ErrorFlags::none(),
+            },
+            None
         )
     )]
     fn test_address_range(msg: Message, expected: Option<RangeInclusive<u16>>) {

--- a/sawp-modbus/src/lib.rs
+++ b/sawp-modbus/src/lib.rs
@@ -1160,7 +1160,7 @@ impl Message {
                         data: _,
                     },
             } => {
-                if *quantity > 0 {
+                if *quantity > 0 && *quantity <= std::u16::MAX - address {
                     Some((address + 1)..=(address + quantity))
                 } else {
                     None


### PR DESCRIPTION
Problem found by fuzzing with
```
Message {
    transaction_id: 0,
    protocol_id: 0,
    length: 6,
    unit_id: 10,
    function: Function {
        raw: 1,
        code: RdCoils,
    },
    access_type: 9,
    category: 1,
    data: Read(
        Request {
            address: 43821,
            quantity: 61951,
        },
    ),
    error_flags: 1,
}
```